### PR TITLE
Buffer archive from S3 in memory instead of to a temporary file

### DIFF
--- a/infra/lambda/index.py
+++ b/infra/lambda/index.py
@@ -39,7 +39,7 @@ def handler(event, context):
         # We do this instead of saving it to a temporary file to avoid running into
         # the Lambda /tmp directory storage limit of 512 MB.
         print('| Downloading S3 archive {}/{}...'.format(bucket, archive_key))
-        archive_bytes = io.BytesIO(s3.get_object(Bucket=bucket, Key=archive_key)['Body'].read())
+        archive_bytes = io.BytesIO(s3.meta.client.get_object(Bucket=bucket, Key=archive_key)['Body'].read())
         print('| Done.')
 
         # Now uncompress the entire archive.


### PR DESCRIPTION
Proof of concept. I have not tried this at all so it may require code tweaks for it to actually compile/work. It also might not even work if we run into Lambda _memory_ limits. But just an idea to try...

Instead of downloading the archive from S3 to a temporary file, buffer it in memory. This should give us some breathing room, freeing up ~135 MB that the `.tar.gz` temp file would have taken up on disk, to avoid reaching Lambda's `/tmp` directory storage limit of 512 MB.

Best to review [ignoring whitespace](https://github.com/pulumi/actions-pulumify/pull/4/files?w=1).

Fixes #3 🤞

Note: I didn't appear to have permissions to create a branch directly in this repo, so created the PR from a fork.