### PR TITLE
Add sync options

### DIFF
--- a/infra/bucketDirectory.ts
+++ b/infra/bucketDirectory.ts
@@ -4,6 +4,7 @@ import * as awsx from "@pulumi/awsx";
 import * as child_process from "child_process";
 import * as fs from "fs";
 import * as https from "https";
+import * as mime from "mime";
 import * as path from "path";
 import * as pulumi from "@pulumi/pulumi";
 import * as tar from "tar";
@@ -13,10 +14,154 @@ import * as uuid from "uuid/v1";
 // TODO(joe): better region management -- since it can be overridden.
 const region = aws.config.region;
 
+/**
+ * BucketDirectory is a component that makes it easy to synchronize an entire local directory in your
+ * project with an S3 Bucket. Individual files will be uploaded as S3 Objects using a strategy of your choice.
+ * This is generally more efficient than manually uploading individual S3 Objects as individual resources.
+ */
 export class BucketDirectory extends pulumi.ComponentResource {
+    /**
+     * The name of this BucketDirectory resource.
+     */
+    public readonly name: string;
+    /**
+     * The synchronization approach taken.
+     */
+    public readonly syncStrategy: BucketSyncStrategy;
+    /**
+     * The relative directory copied into the bucket.
+     */
+    public readonly source: string;
+    /**
+     * The S3 bucket the contents have been copied to.
+     */
+    public readonly bucket: aws.s3.Bucket;
+    /**
+     * The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) applied, if any.
+     */
+    public readonly objectAcl?: string;
+
+    /**
+     * The child resource allocated to perform the directory sync'ing.
+     */
+    private readonly syncer: BucketDirectoryLambdaSyncer;
+
+    /**
+     * Provisions a new BucketDirectory resource with a given name, arguments, and options.
+     */
     constructor(name: string, args: BucketDirectoryArgs, opts?: pulumi.ComponentResourceOptions) {
         super("awsx:s3:BucketDirectory", name, args, opts);
 
+        this.name = name;
+        this.syncStrategy = args.syncStrategy || "server-lambda";
+        this.source = args.source;
+        this.bucket = args.bucket;
+        this.objectAcl = args.objectAcl;
+
+        switch (this.syncStrategy) {
+            case "server-lambda":
+                this.syncServerLambda();
+                break;
+            case "server-ecstask":
+                this.syncServerEcsTask();
+                break;
+            case "local-sync":
+                this.syncLocalSync();
+                break;
+            case "local-copy":
+                this.syncLocalCopy();
+                break;
+            default:
+                throw new Error(`Unrecognized syncStratety: ${this.syncStrategy}`);
+        }
+    }
+
+    /**
+     * syncServerLambda compresses and uploads an entire directory as an object to a bucket and then uses server-side
+     * copying to maximize bandwidth. Unfortunately, due to lambda limitations, this stops working at 512MB.
+     */
+    private syncServerLambda(): void {
+        // Create a temporary file containing the contents and upload it.
+        const archive = this.createTempArchive();
+
+        // Create the dynamic resource that'll decompress and bulk-sync the contents.
+        const syncer = new BucketDirectoryLambdaSyncer(`${this.name}-syncer`, {
+            archive,
+            objectAcl: this.objectAcl,
+        }, { parent: this });
+    }
+
+    private syncServerEcsTask(): void {
+        // Create a temporary file containing the contents and upload it.
+        const archive = this.createTempArchive();
+
+        // Create the dynamic resource that'll decompress and bulk-sync the contents.
+        const syncer = new BucketDirectoryEcsTaskSyncer(`${this.name}-syncer`, {
+            archive,
+            objectAcl: this.objectAcl,
+        }, { parent: this });
+    }
+
+    /**
+     * syncLocalSync uses the `aws s3 sync` command, via the CLI, to synchronize a folder with a target S3
+     * Bucket. This copies a file at a time from the client but is slightly more efficient than materializing
+     * an actual Pulumi asset and resource for every S3 Object.
+     */
+    private syncLocalSync(): void {
+        // TODO(joe): unfortunately, because this is guarded, previews won't show that updates will occur.
+        if (!pulumi.runtime.isDryRun()) {
+            this.bucket.bucket.apply(bucket => {
+                try {
+                    let cmd = `aws s3 sync ${this.source} s3://${bucket}`;
+                    if (this.objectAcl) {
+                        cmd += ` --acl="${this.objectAcl}"`;
+                    }
+                    child_process.execSync(cmd, { maxBuffer: 1024*1024*1024 });
+                } catch (err) {
+                    pulumi.log.error(`synchronizing ${this.source} to s3://${bucket} failed: ${err}`);
+                }
+            });
+        }
+    }
+
+    /**
+     * syncLocalCopy just traverses the filesystem recursively, and creates an S3 Object resource for each file.
+     * This creates an asset and resource which isn't the most efficient approach, but works.
+     */
+    private syncLocalCopy(): void {
+        // crawlDirectory recursive crawls the provided directory, applying the provided function
+        // to every file it contains. Doesn't handle cycles from symlinks.
+        function crawlDirectory(dir: string, f: (_: string) => void) {
+            const files = fs.readdirSync(dir);
+            for (const file of files) {
+                const filePath = `${dir}/${file}`;
+                const stat = fs.statSync(filePath);
+                if (stat.isDirectory()) {
+                    crawlDirectory(filePath, f);
+                }
+                if (stat.isFile()) {
+                    f(filePath);
+                }
+            }
+        }
+
+        crawlDirectory(this.source, (filePath: string) => {
+            const relativeFilePath = filePath.replace(this.source + "/", "");
+            const contentFile = new aws.s3.BucketObject(`${this.name}/${relativeFilePath}`, {
+                acl: this.objectAcl,
+                key: relativeFilePath,
+                bucket: this.bucket,
+                source: new pulumi.asset.FileAsset(filePath),
+                contentType: mime.getType(filePath) || undefined,
+            }, { parent: this });
+        });
+    }
+
+    /**
+     * createTempArchive is shared between the server-side variants (Lambda and ECS) to produce a temporary
+     * archive that is uploaded to a bucket, so that we can hand off expensive copying to the server-side.
+     */
+    private createTempArchive(): aws.s3.BucketObject {
         // Upload the target directory a single object at a time. This allows us to minimize
         // copying over the Internet, and then to apply an efficient "S3 sync" from within the
         // Amazon data center, where bandwidth to the target S3 bucket will be maximized.
@@ -28,24 +173,18 @@ export class BucketDirectory extends pulumi.ComponentResource {
             gzip: true,
             sync: true,
             file: arch,
-            C: args.source,
+            C: this.source,
             portable: true,
-        }, fs.readdirSync(args.source));
+        }, fs.readdirSync(this.source));
 
         // TODO(joe): when archive can be an asset, we can just use this line, instead of manual tgzing:
         // const arch = new pulumi.asset.FileArchive(args.source);
 
-        // Now create a single object in the target bucket to hold the resulting archive.
-        const archive = new aws.s3.BucketObject(`${name}-archive`, {
+        // Now create a single object in the target bucket to hold the resulting archive and return it.
+        return new aws.s3.BucketObject(`${this.name}-archive`, {
             key: "__aws.s3.BucketDirectory.archive.tar.gz",
-            bucket: args.bucket,
+            bucket: this.bucket,
             source: new pulumi.asset.FileAsset(arch),
-        }, { parent: this });
-
-        // Create the dynamic resource that'll decompress and bulk-sync the contents.
-        const syncer = new BucketDirectorySyncer(`${name}-syncer`, {
-            archive,
-            objectAcl: args.objectAcl,
         }, { parent: this });
     }
 }
@@ -61,66 +200,108 @@ export interface BucketDirectoryArgs {
      */
     source: string;
     /**
+     * The synchronization approach to take. If empty, the "server-lambda" strartegy is used, as it is the fastest.
+     */
+    syncStrategy?: BucketSyncStrategy;
+    /**
      * The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply.
      * Defaults to "private".
      */
     objectAcl?: string;
 }
 
-async function invokeSync(inputs: any, action: string): Promise<void> {
-    try {
-        const bucket = inputs["bucket"] as string;
-        if (!bucket) {
-            throw new Error("Missing bucket in BucketDirectory inputs");
-        }
-        const archiveKey = inputs["archiveKey"] as string;
-        if (!archiveKey) {
-            throw new Error("Missing archiveKey in BucketDirectory inputs");
-        }
-        const objectAcl = inputs["objectAcl"] as string;
-        const syncFunc = inputs["syncFunc"] as string;
-        if (!syncFunc) {
-            throw new Error("Missing syncFunc ARN in BucketDirectory inputs");
-        }
+/**
+ * BucketSyncStrategy controls how S3 objects are sync'd from the local project to the destination bucket.
+ * This provides a set of options ranging from fast to slow, each with its own performance limits and characteristics.
+ *
+ * WARNING: switching between sync strategies will result in a period of time where your bucket is empty.
+ */
+export type BucketSyncStrategy =
+    /**
+     * The "server-lambda" strategy is generally fastest and cheapest option, however is limited by AWS Lambda's
+     * standard memory and compute limitations. A single tgz will be produced and uploaded to a temporary bucket,
+     * minimizing transfer time, and then the Lambda will sync the contents, maximizing S3 proximity and bandwidth.
+     * Namely, for large contents exceeding 512MB, this approach will not work.
+     */
+    "server-lambda" |
+    /**
+     * The "server-ecstask" strategy is generally fast and cheap option, however requires that an ECS "Fargate"
+     * cluster is provisioned, and so may cost more than "server-lambda," and is also limited by standard ECS "Fargate"
+     * memory and compute limitations. A single tgz will be produced and uploaded to a temporary bucket, minimizing
+     * transfer time, and then the Lambda will sync the contents, maximizing S3 proximity and bandwidth.
+     */
+    "server-ecstask" |
+    /**
+     * The "local-sync" strategy will run an `aws s3 sync` command locally to copy files. This uses optimizations
+     * built into the AWS CLI, however is approximately equivalent to copying individual objects. This is slower than
+     * the "server-*" family of strategies because files are not compressed while uploading.
+     */
+    "local-sync" |
+    /**
+     * The "local-copy" strategy will upload individual objects to your bucket one at a time. This will generally be
+     * slower than "local-sync", because every S3 object will result in a distinct Pulumi asset and resource. This is
+     * slower than the "server-*" family of strategies because files are not compressed while uploading.
+     */
+    "local-copy"
+;
 
-        // Run the copy function and then wait for it to finish.
-        const lambda = new awssdk.Lambda({ region });
-        const resp = await lambda.invoke({
-            FunctionName: syncFunc,
-            Payload: JSON.stringify({
-                Action: action,
-                Bucket: bucket,
-                ArchiveKey: archiveKey,
-                ObjectAcl: objectAcl,
-            }),
-        }).promise();
-        if (resp && resp.FunctionError) {
-            throw new Error(
-                `Invoking sync function '${syncFunc}' failed [${resp.FunctionError}]: ${JSON.stringify(resp.Payload)}`);
+/**
+ * BucketDirectoryLambdaSyncer is the implementation of the "server-lambda" sync strategy.
+ */
+class BucketDirectoryLambdaSyncer extends pulumi.dynamic.Resource  {
+    private static async invokeSync(inputs: any, action: string): Promise<void> {
+        try {
+            const bucket = inputs["bucket"] as string;
+            if (!bucket) {
+                throw new Error("Missing bucket in BucketDirectory inputs");
+            }
+            const archiveKey = inputs["archiveKey"] as string;
+            if (!archiveKey) {
+                throw new Error("Missing archiveKey in BucketDirectory inputs");
+            }
+            const objectAcl = inputs["objectAcl"] as string;
+            const syncFunc = inputs["syncFunc"] as string;
+            if (!syncFunc) {
+                throw new Error("Missing syncFunc ARN in BucketDirectory inputs");
+            }
+
+            // Run the copy function and then wait for it to finish.
+            const lambda = new awssdk.Lambda({ region });
+            const resp = await lambda.invoke({
+                FunctionName: syncFunc,
+                Payload: JSON.stringify({
+                    Action: action,
+                    Bucket: bucket,
+                    ArchiveKey: archiveKey,
+                    ObjectAcl: objectAcl,
+                }),
+            }).promise();
+            if (resp && resp.FunctionError) {
+                throw new Error(
+                    `Invoking sync function '${syncFunc}' failed [${resp.FunctionError}]: ${JSON.stringify(resp.Payload)}`);
+            }
+        } catch (err) {
+            // TODO[pulumi/pulumi#2721]: this can go away once diagnostics for dynamic providers is improved.
+            console.log(err);
+            throw err;
         }
-    } catch (err) {
-        // TODO[pulumi/pulumi#2721]: this can go away once diagnostics for dynamic providers is improved.
-        console.log(err);
-        throw err;
     }
-}
 
-class BucketDirectorySyncer extends pulumi.dynamic.Resource  {
-    static provider = {
+    private static provider = {
         create: async(inputs: any): Promise<pulumi.dynamic.CreateResult> => {
-            await invokeSync(inputs, "Update");
+            await BucketDirectoryLambdaSyncer.invokeSync(inputs, "Create");
             return { id: uuid(), outs: inputs };
         },
         update: async(id: pulumi.ID, olds: any, news: any): Promise<pulumi.dynamic.UpdateResult> => {
-            await invokeSync(news, "Update");
+            await BucketDirectoryLambdaSyncer.invokeSync(news, "Update");
             return { outs: news };
         },
         delete: async(id: pulumi.ID, olds: any): Promise<void> => {
-            await invokeSync(olds, "Delete");
+            await BucketDirectoryLambdaSyncer.invokeSync(olds, "Delete");
         },
     };
 
-    static createSyncFunc(name: string, bucket: pulumi.Output<string>, parent?: pulumi.Resource): pulumi.Output<string> {
+    private static createSyncFunc(name: string, bucket: pulumi.Output<string>, parent?: pulumi.Resource): pulumi.Output<string> {
         const syncFuncRole = new aws.iam.Role(`${name}-copyfunc-role`, {
             assumeRolePolicy: {
                 Version: "2012-10-17",
@@ -195,7 +376,7 @@ class BucketDirectorySyncer extends pulumi.dynamic.Resource  {
     constructor(name: string, args: BucketDirectorySyncerArgs, opts?: pulumi.ResourceOptions) {
         // Create a Lambda function that will copy and extract files using "aws s3 sync".
         opts = opts || {};
-        const syncFunc = BucketDirectorySyncer.createSyncFunc(name, args.archive.bucket, opts.parent);
+        const syncFunc = BucketDirectoryLambdaSyncer.createSyncFunc(name, args.archive.bucket, opts.parent);
 
         // Now initialize the dynamic resource provider, etc.
         const superArgs = {
@@ -205,9 +386,149 @@ class BucketDirectorySyncer extends pulumi.dynamic.Resource  {
             archiveEtag: args.archive.etag,
             objectAcl: args.objectAcl,
         };
-        super(BucketDirectorySyncer.provider, name, superArgs, opts);
+        super(BucketDirectoryLambdaSyncer.provider, name, superArgs, opts);
     }
 }
+
+async function invokeTaskSync(inputs: any, action: string): Promise<void> {
+    try {
+        const bucket = inputs["bucket"] as string;
+        if (!bucket) {
+            throw new Error("Missing bucket in BucketDirectory inputs");
+        }
+        const archiveKey = inputs["archiveKey"] as string;
+        if (!archiveKey) {
+            throw new Error("Missing archiveKey in BucketDirectory inputs");
+        }
+        const objectAcl = inputs["objectAcl"] as string;
+        if (!objectAcl) {
+            throw new Error("Missing objectAcl in BucketDirectory inputs");
+        }
+        const syncCluster = inputs["syncCluster"] as string;
+        if (!syncCluster) {
+            throw new Error("Missing syncCluster ARN in BucketDirectory inputs");
+        }
+        const syncSecurityGroupIds = inputs["syncSecurityGroupIds"] as string[];
+        if (!syncSecurityGroupIds) {
+            throw new Error("Missing syncSecurityGroupIds in BucketDirectoryInputs");
+        }
+        const syncSubnetIds = inputs["syncSubnetIds"] as string[];
+        if (!syncSubnetIds) {
+            throw new Error("Missing syncSubnetIds in BucketDirectoryInputs");
+        }
+        const syncTask = inputs["syncTask"] as string;
+        if (!syncTask) {
+            throw new Error("Missing syncTask ARN in BucketDirectory inputs");
+        }
+
+        // Kick off the task to perform the copying.
+        const ecs = new awssdk.ECS({ region });
+        const runResp = await ecs.runTask({
+            cluster: syncCluster,
+            taskDefinition: syncTask,
+            launchType: "FARGATE",
+            networkConfiguration: {
+                awsvpcConfiguration: {
+                    assignPublicIp: "ENABLED",
+                    securityGroups: syncSecurityGroupIds,
+                    subnets: syncSubnetIds,
+                },
+            },
+            overrides: {
+                containerOverrides: [
+                    {
+                        name: "container",
+
+                        // Pass the S3 URL of the uploaded tarball and destination
+                        // bucket to the container task.
+                        command: [
+                            action,
+                            bucket,
+                            archiveKey,
+                            objectAcl,
+                        ],
+                    },
+                ],
+            },
+        }).promise();
+        if (runResp && runResp.failures && runResp.failures.length) {
+            throw new Error(
+                `Invoking ECS task '${syncTask}' failed: ${JSON.stringify(runResp.failures)}`);
+        }
+
+        // Now wait for it to complete.
+        // TODO(joe): note that this won't necessarily include failure information, because when
+        //     a task fails, we need to inspect the logs to figure out why it failed.
+        const waitResp = await ecs.waitFor("tasksStopped", {
+            cluster: syncCluster,
+            tasks: (runResp.tasks || []).map(t => t.taskArn!),
+        }).promise();
+        if (waitResp && waitResp.failures && waitResp.failures.length) {
+            throw new Error(
+                `Waiting for ECS task '${syncTask}' failed: ${JSON.stringify(runResp.failures)}`);
+        }
+    } catch (err) {
+        // TODO[pulumi/pulumi#2721]: this can go away once diagnostics for dynamic providers is improved.
+        console.log(err);
+        throw err;
+    }
+}
+
+/**
+ * BucketDirectoryEcsTaskSyncer is the implementation of the "server-ecstask" sync strategy.
+ */
+class BucketDirectoryEcsTaskSyncer extends pulumi.dynamic.Resource  {
+    private static provider = {
+        create: async(inputs: any): Promise<pulumi.dynamic.CreateResult> => {
+            await invokeTaskSync(inputs, "Create");
+            return { id: uuid(), outs: inputs };
+        },
+        update: async(id: pulumi.ID, olds: any, news: any): Promise<pulumi.dynamic.UpdateResult> => {
+            if (olds.archiveEtag !== news.archiveEtag) {
+                await invokeTaskSync(news, "Update");
+            }
+            return { outs: news };
+        },
+        delete: async(id: pulumi.ID, olds: any): Promise<void> => {
+            await invokeTaskSync(olds, "Delete");
+        },
+    };
+
+    private static createSyncTask(name: string, bucket: pulumi.Output<string>, parent?: pulumi.Resource): pulumi.Output<string> {
+        // archiveHandler processes the uploads when they become available.
+        const archiveHandler = new awsx.ecs.FargateTaskDefinition(`${name}-synctask`, {
+            container: {
+                image: awsx.ecs.Image.fromPath(`${name}-synctask-img`, "ecstask"),
+                memory: 4096,
+                cpu: 4,
+            },
+        }, { parent });
+
+        // Return the handler's ARN.
+        return archiveHandler.taskDefinition.arn;
+    }
+
+    constructor(name: string, args: BucketDirectorySyncerArgs, opts?: pulumi.ResourceOptions) {
+        // Create an ECS Task that will copy and extract files using "aws s3 sync".
+        opts = opts || {};
+        const syncCluster = awsx.ecs.Cluster.getDefault();
+        const syncTask = BucketDirectoryEcsTaskSyncer.createSyncTask(name, args.archive.bucket, opts.parent);
+
+        // Now initialize the dynamic resource provider, etc.
+        const superArgs = {
+            syncCluster: syncCluster.cluster.arn,
+            syncSecurityGroupIds: syncCluster.securityGroups.map(sg => sg.id),
+            syncSubnetIds: syncCluster.vpc.publicSubnetIds,
+            syncTask,
+            bucket: args.archive.bucket,
+            archiveKey: args.archive.key,
+            archiveEtag: args.archive.etag,
+            objectAcl: args.objectAcl || "private",
+        };
+        super(BucketDirectoryEcsTaskSyncer.provider, name, superArgs, opts);
+    }
+}
+
 
 interface BucketDirectorySyncerArgs {
     /**

--- a/infra/ecstask/Dockerfile
+++ b/infra/ecstask/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:alpine
+
+RUN pip install --no-cache-dir awscli
+COPY sync.sh /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/sync.sh"]

--- a/infra/ecstask/sync.sh
+++ b/infra/ecstask/sync.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -e
+
+# Determine the action type.
+action="$1"
+if [ -z "$action" ]; then
+    echo "error: missing argument: action"
+    exit 1
+fi
+
+# Get the object bucket/key to expand.
+bucket="$2"
+archive="$3"
+object_acl="$4"
+
+if [ -z "$bucket" ]; then
+    echo "error: missing argument: bucket"
+    exit 1
+elif [ -z "$archive" ]; then
+    echo "error: missing argument: archive"
+    exit 1
+elif [ -z "$object_acl" ]; then
+    echo "error: missing argument: object_acl"
+    exit 1
+fi
+
+if [ "$action" == "Create" ] || [ "$action" == "Update" ]; then
+    # Download the archive from the archive bucket and unpack it into a local folder.
+    echo "| Downloading S3 archive $bucket/$archive..."
+    aws s3 cp s3://$bucket/$archive .
+    echo "| Done."
+    TMP_ARCHIVE_DIR=site_contents
+    echo "| Decompressing archive to $TMP_ARCHIVE_DIR..."
+    mkdir $TMP_ARCHIVE_DIR
+    tar -xzvf $archive -C $TMP_ARCHIVE_DIR
+    echo "| Done."
+
+    # Synchronize the contents of the local folder and site bucket, deleting
+    # whatever files exist remotely but not locally.
+    echo "| Running AWS CLI to sync to $bucket (with ACL $object_acl)..."
+    aws s3 sync $TMP_ARCHIVE_DIR s3://$bucket --acl "$object_acl" --delete
+    echo "| Done."
+
+    rm -rf $TMP_ARCHIVE_DIR
+elif [ "$action" == "Delete" ]; then
+    echo "| Running AWS CLI to delete entire bucket $bucket..."
+    aws s3 rm s3://$bucket --recursive
+    echo "| Done."
+else
+    echo "error: unrecognized action: $action"
+    exit 1
+fi

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -31,7 +31,7 @@ const content = new BucketDirectory("content", {
     bucket: contentBucket,
     source: contentRoot,
     objectAcl: "public-read",
-    syncStrategy: syncStrategy,
+    syncStrategy: <any>syncStrategy,
 }, { parent: contentBucket });
 
 // Export the bucket name.

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -30,6 +30,7 @@ const content = new BucketDirectory("content", {
     bucket: contentBucket,
     source: contentRoot,
     objectAcl: "public-read",
+    syncStrategy: "server-ecstask",
 }, { parent: contentBucket });
 
 // Export the bucket name.

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -8,6 +8,7 @@ import { BucketDirectory } from "./bucketDirectory";
 // The content comes from a configurable location.
 const config = new pulumi.Config();
 const contentRoot = config.require("root");
+const syncStrategy = config.get("syncStrategy");
 
 // Create a bucket to store and serve the static content.
 const contentBucket = new aws.s3.Bucket("content-bucket", {
@@ -30,7 +31,7 @@ const content = new BucketDirectory("content", {
     bucket: contentBucket,
     source: contentRoot,
     objectAcl: "public-read",
-    syncStrategy: "server-ecstask",
+    syncStrategy: syncStrategy,
 }, { parent: contentBucket });
 
 // Export the bucket name.

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -4,18 +4,18 @@
     "lockfileVersion": 1,
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-            "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+            "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.0.0"
+                "@babel/highlight": "^7.8.3"
             }
         },
         "@babel/highlight": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-            "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+            "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
             "dev": true,
             "requires": {
                 "chalk": "^2.0.0",
@@ -78,11 +78,11 @@
             "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
         },
         "@pulumi/aws": {
-            "version": "0.18.27",
-            "resolved": "https://registry.npmjs.org/@pulumi/aws/-/aws-0.18.27.tgz",
-            "integrity": "sha512-jrtgV3hfxsebttliQxBGGZaUSwiJsgc0VlpIaJPrggMOi1pDPYDlYRPUS2PRi972gE6C1ddBlViRisdqVF9UAg==",
+            "version": "1.23.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/aws/-/aws-1.23.0.tgz",
+            "integrity": "sha512-nAl+GdbGDE+fGwnT2VQQJ5aWsJhL/Z5DHOV+hHgP+ksadpl6U1f/F64Ln+3nu92imYSvexDcnR/tH1dYjo0rWQ==",
             "requires": {
-                "@pulumi/pulumi": "^0.17.27",
+                "@pulumi/pulumi": "^1.0.0",
                 "aws-sdk": "^2.0.0",
                 "builtin-modules": "3.0.0",
                 "mime": "^2.0.0",
@@ -91,117 +91,43 @@
             }
         },
         "@pulumi/awsx": {
-            "version": "0.18.8",
-            "resolved": "https://registry.npmjs.org/@pulumi/awsx/-/awsx-0.18.8.tgz",
-            "integrity": "sha512-oLw1C7+DSQzdgrMmSzMCsfOAJyFuTkq5EdkDFMhR2JUcdD64UsxgThOqld1/OUJ31j0zclz83fRpiRu6tV+vHA==",
+            "version": "0.18.14",
+            "resolved": "https://registry.npmjs.org/@pulumi/awsx/-/awsx-0.18.14.tgz",
+            "integrity": "sha512-2etPn1fCPSk+xpIow9vqS398SVmNZlmJe3gP7icWSZeaON8ActfYE/89JEWLSSkWkzc7h8P+LavkLg2sYWmGnw==",
             "requires": {
-                "@pulumi/aws": "^0.18.24",
-                "@pulumi/docker": "^0.17.2",
-                "@pulumi/pulumi": "^0.17.27",
+                "@pulumi/aws": "^1.0.0",
+                "@pulumi/docker": "^0.17.3",
+                "@pulumi/pulumi": "^1.0.0",
                 "@types/aws-lambda": "^8.10.23",
                 "deasync": "^0.1.15",
                 "mime": "^2.0.0"
-            },
-            "dependencies": {
-                "@pulumi/aws": {
-                    "version": "0.18.26",
-                    "resolved": "https://registry.npmjs.org/@pulumi/aws/-/aws-0.18.26.tgz",
-                    "integrity": "sha512-YqaLsIUZIt5RacLSV7/GhS+brkLfuBGq/r0ktk7k+xyH0cl8nQjgnG0z9B7MRRagh5BijpMMA06GbIhIx1Ar3Q==",
-                    "requires": {
-                        "@pulumi/pulumi": "^0.17.27",
-                        "aws-sdk": "^2.0.0",
-                        "builtin-modules": "3.0.0",
-                        "mime": "^2.0.0",
-                        "read-package-tree": "^5.2.1",
-                        "resolve": "^1.7.1"
-                    }
-                },
-                "@pulumi/pulumi": {
-                    "version": "0.17.28",
-                    "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-0.17.28.tgz",
-                    "integrity": "sha512-pVKahH9Ryl6wIpzdOKjsu2gEshDCA7elB34paJpPXw+3ARViSPri7y/2uTdmMRg36jsbrOdNGEohKJEqIZLioA==",
-                    "requires": {
-                        "@pulumi/query": "^0.3.0",
-                        "deasync": "^0.1.15",
-                        "google-protobuf": "^3.5.0",
-                        "grpc": "1.21.1",
-                        "minimist": "^1.2.0",
-                        "normalize-package-data": "^2.4.0",
-                        "protobufjs": "^6.8.6",
-                        "read-package-tree": "^5.3.1",
-                        "require-from-string": "^2.0.1",
-                        "semver": "^6.1.0",
-                        "source-map-support": "^0.4.16",
-                        "ts-node": "^7.0.0",
-                        "typescript": "^3.0.0",
-                        "upath": "^1.1.0"
-                    }
-                },
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                },
-                "typescript": {
-                    "version": "3.5.3",
-                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-                    "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g=="
-                }
             }
         },
         "@pulumi/docker": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@pulumi/docker/-/docker-0.17.2.tgz",
-            "integrity": "sha512-P/V97GjxVO+8rQ8AY5Dn3VkjuxqeL5d0yiZc9DWfIbXAPrwZk4p2xP+NSCACccGX0DxX3Pq25UIuX74JCkXLkw==",
+            "version": "0.17.4",
+            "resolved": "https://registry.npmjs.org/@pulumi/docker/-/docker-0.17.4.tgz",
+            "integrity": "sha512-uGnt9VEGXxCFTpIkCrULP2XTbSEJMH3vQrOq9Q+ATTnIxswlG0z/LkpuktEB6YmvnQqEUtTPPEM+p/RmLkqLrA==",
             "requires": {
-                "@pulumi/pulumi": "^0.17.23",
+                "@pulumi/pulumi": "^1.0.0",
                 "semver": "^5.4.0"
             },
             "dependencies": {
-                "@pulumi/pulumi": {
-                    "version": "0.17.28",
-                    "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-0.17.28.tgz",
-                    "integrity": "sha512-pVKahH9Ryl6wIpzdOKjsu2gEshDCA7elB34paJpPXw+3ARViSPri7y/2uTdmMRg36jsbrOdNGEohKJEqIZLioA==",
-                    "requires": {
-                        "@pulumi/query": "^0.3.0",
-                        "deasync": "^0.1.15",
-                        "google-protobuf": "^3.5.0",
-                        "grpc": "1.21.1",
-                        "minimist": "^1.2.0",
-                        "normalize-package-data": "^2.4.0",
-                        "protobufjs": "^6.8.6",
-                        "read-package-tree": "^5.3.1",
-                        "require-from-string": "^2.0.1",
-                        "semver": "^6.1.0",
-                        "source-map-support": "^0.4.16",
-                        "ts-node": "^7.0.0",
-                        "typescript": "^3.0.0",
-                        "upath": "^1.1.0"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "6.3.0",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                        }
-                    }
-                },
-                "typescript": {
-                    "version": "3.5.3",
-                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-                    "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g=="
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
                 }
             }
         },
         "@pulumi/pulumi": {
-            "version": "0.17.28",
-            "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-0.17.28.tgz",
-            "integrity": "sha512-pVKahH9Ryl6wIpzdOKjsu2gEshDCA7elB34paJpPXw+3ARViSPri7y/2uTdmMRg36jsbrOdNGEohKJEqIZLioA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-1.11.1.tgz",
+            "integrity": "sha512-f3s1vghGAt3wVtBAuahbEdNp1X6iP0xTA8aSSmzwkHGfSdOu9FLERXRLJVsTZRBVshF1Jh+0wHYdRLahWxVpJw==",
             "requires": {
                 "@pulumi/query": "^0.3.0",
                 "deasync": "^0.1.15",
                 "google-protobuf": "^3.5.0",
-                "grpc": "1.21.1",
+                "grpc": "1.24.2",
                 "minimist": "^1.2.0",
                 "normalize-package-data": "^2.4.0",
                 "protobufjs": "^6.8.6",
@@ -209,20 +135,15 @@
                 "require-from-string": "^2.0.1",
                 "semver": "^6.1.0",
                 "source-map-support": "^0.4.16",
-                "ts-node": "^7.0.0",
-                "typescript": "^3.0.0",
+                "ts-node": "8.5.4",
+                "typescript": "~3.7.3",
                 "upath": "^1.1.0"
             },
             "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                },
                 "typescript": {
-                    "version": "3.5.3",
-                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-                    "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g=="
+                    "version": "3.7.5",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+                    "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw=="
                 }
             }
         },
@@ -232,14 +153,30 @@
             "integrity": "sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w=="
         },
         "@types/aws-lambda": {
-            "version": "8.10.31",
-            "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.31.tgz",
-            "integrity": "sha512-xcmOvzVILQoex1oR+vjKnBP3OJn+g92r3yVzeTSmRgLQwBvSOghRPRSx3rVMQivLzAIR6atxlVu3AV9bxc/hQw=="
+            "version": "8.10.46",
+            "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.46.tgz",
+            "integrity": "sha512-88E4Hlypo3AE40wslm7N4n09lCIJwgYJm5wsaA3/Vib1xqjC/ANePTaPRpPdj9NzBSpw7Tgon58qGMYEArx4oA=="
+        },
+        "@types/bytebuffer": {
+            "version": "5.0.40",
+            "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
+            "integrity": "sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==",
+            "requires": {
+                "@types/long": "*",
+                "@types/node": "*"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "13.7.7",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.7.tgz",
+                    "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg=="
+                }
+            }
         },
         "@types/long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+            "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
         },
         "@types/mime": {
             "version": "2.0.1",
@@ -253,12 +190,20 @@
             "integrity": "sha512-wuzZksN4w4kyfoOv/dlpov4NOunwutLA/q7uc00xU02ZyUY+aoM5PWIXEKBMnm0NHd4a+N71BMjq+x7+2Af1fg==",
             "requires": {
                 "@types/node": "*"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "13.7.7",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.7.tgz",
+                    "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg=="
+                }
             }
         },
         "@types/node": {
-            "version": "12.7.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
-            "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
+            "version": "12.12.29",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.29.tgz",
+            "integrity": "sha512-yo8Qz0ygADGFptISDj3pOC9wXfln/5pQaN/ysDIzOaAWXt73cNHmtEC8zSO2Y+kse/txmwIAJzkYZ5fooaS5DQ==",
+            "dev": true
         },
         "@types/tar": {
             "version": "4.0.3",
@@ -267,6 +212,13 @@
             "requires": {
                 "@types/minipass": "*",
                 "@types/node": "*"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "13.7.7",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.7.tgz",
+                    "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg=="
+                }
             }
         },
         "@types/tmp": {
@@ -275,12 +227,9 @@
             "integrity": "sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA=="
         },
         "@types/uuid": {
-            "version": "3.4.5",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.5.tgz",
-            "integrity": "sha512-MNL15wC3EKyw1VLF+RoVO4hJJdk9t/Hlv3rt1OL65Qvuadm4BYo6g9ZJQqoq7X8NBFSsQXgAujWciovh2lpVjA==",
-            "requires": {
-                "@types/node": "*"
-            }
+            "version": "3.4.8",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.8.tgz",
+            "integrity": "sha512-zHWce3allXWSmRx6/AGXKCtSOA7JjeWd2L3t4aHfysNk8mouQnWCocveaT7a4IEIlPVHp81jzlnknqTgCjCLXA=="
         },
         "ansi-regex": {
             "version": "2.1.1",
@@ -296,6 +245,11 @@
                 "color-convert": "^1.9.0"
             }
         },
+        "arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+        },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -304,11 +258,6 @@
             "requires": {
                 "sprintf-js": "~1.0.2"
             }
-        },
-        "arrify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
         },
         "asap": {
             "version": "2.0.6",
@@ -325,19 +274,26 @@
             }
         },
         "aws-sdk": {
-            "version": "2.504.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.504.0.tgz",
-            "integrity": "sha512-azOX54oovJv0zWzO23fBgIprwsvx8KUuMR+cAUAOx23D8LJ5S+sl3UYS9Q1X4qF/blBTa4+ZNawZDV0N1HiQmw==",
+            "version": "2.631.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.631.0.tgz",
+            "integrity": "sha512-oGYe21pc8b1rxJFZMETZIhY4e/QBJv8Keq4RCef3D/GNXR+oxDQsEDk9KchbkW0WJDxiglj3LnZzPYUhISnBbw==",
             "requires": {
                 "buffer": "4.9.1",
                 "events": "1.1.1",
-                "ieee754": "1.1.8",
+                "ieee754": "1.1.13",
                 "jmespath": "0.15.0",
                 "querystring": "0.2.0",
                 "sax": "1.2.1",
                 "url": "0.10.3",
                 "uuid": "3.3.2",
                 "xml2js": "0.4.19"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "3.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+                }
             }
         },
         "balanced-match": {
@@ -346,14 +302,17 @@
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base64-js": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
         },
         "bindings": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-            "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -409,9 +368,9 @@
             }
         },
         "chownr": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
-            "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         },
         "cliui": {
             "version": "3.2.0",
@@ -449,9 +408,9 @@
             "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
         },
         "commander": {
-            "version": "2.20.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-            "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true
         },
         "concat-map": {
@@ -460,12 +419,12 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "deasync": {
-            "version": "0.1.15",
-            "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.15.tgz",
-            "integrity": "sha512-pxMaCYu8cQIbGkA4Y1R0PLSooPIpH1WgFBLeJ+zLxQgHfkZG86ViJSmZmONSjZJ/R3NjwkMcIWZAzpLB2G9/CA==",
+            "version": "0.1.19",
+            "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.19.tgz",
+            "integrity": "sha512-oh3MRktfnPlLysCPpBpKZZzb4cUC/p0aA3SyRGp15lN30juJBTo/CiD0d4fR+f1kBtUQoJj1NE9RPNWQ7BQ9Mg==",
             "requires": {
-                "bindings": "~1.2.1",
-                "node-addon-api": "^1.6.0"
+                "bindings": "^1.5.0",
+                "node-addon-api": "^1.7.1"
             }
         },
         "debuglog": {
@@ -496,27 +455,32 @@
             }
         },
         "diff": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
         },
         "es-abstract": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-            "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+            "version": "1.17.4",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+            "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
             "requires": {
-                "es-to-primitive": "^1.2.0",
+                "es-to-primitive": "^1.2.1",
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
-                "is-callable": "^1.1.4",
-                "is-regex": "^1.0.4",
-                "object-keys": "^1.0.12"
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.1.5",
+                "is-regex": "^1.0.5",
+                "object-inspect": "^1.7.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.0",
+                "string.prototype.trimleft": "^2.1.1",
+                "string.prototype.trimright": "^2.1.1"
             }
         },
         "es-to-primitive": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-            "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
             "requires": {
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
@@ -536,9 +500,9 @@
             "dev": true
         },
         "esutils": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
         },
         "events": {
@@ -546,12 +510,17 @@
             "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
             "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
         },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+        },
         "fs-minipass": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
-            "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+            "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
             "requires": {
-                "minipass": "^2.2.1"
+                "minipass": "^2.6.0"
             }
         },
         "fs.realpath": {
@@ -565,9 +534,9 @@
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "glob": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-            "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -578,24 +547,25 @@
             }
         },
         "google-protobuf": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.9.1.tgz",
-            "integrity": "sha512-tkz7SVwBktFbqFK3teXFUY/VM57+mbUgV9bSD+sZH1ocHJ7uk7BfEWMRdU24dd0ciUDokreA7ghH2fYFIczQdw=="
+            "version": "3.11.4",
+            "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.11.4.tgz",
+            "integrity": "sha512-lL6b04rDirurUBOgsY2+LalI6Evq8eH5TcNzi7TYQ3BsIWelT0KSOQSBsXuavEkNf+odQU6c0lgz3UsZXeNX9Q=="
         },
         "graceful-fs": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-            "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw=="
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+            "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
         },
         "grpc": {
-            "version": "1.21.1",
-            "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.21.1.tgz",
-            "integrity": "sha512-PFsZQazf62nP05a0xm23mlImMuw5oVlqF/0zakmsdqJgvbABe+d6VThY2PfhqJmWEL/FhQ6QNYsxS5EAM6++7g==",
+            "version": "1.24.2",
+            "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.2.tgz",
+            "integrity": "sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==",
             "requires": {
+                "@types/bytebuffer": "^5.0.40",
                 "lodash.camelcase": "^4.3.0",
                 "lodash.clone": "^4.5.0",
                 "nan": "^2.13.2",
-                "node-pre-gyp": "^0.13.0",
+                "node-pre-gyp": "^0.14.0",
                 "protobufjs": "^5.0.3"
             },
             "dependencies": {
@@ -632,7 +602,7 @@
                     }
                 },
                 "chownr": {
-                    "version": "1.1.1",
+                    "version": "1.1.3",
                     "bundled": true
                 },
                 "code-point-at": {
@@ -651,6 +621,13 @@
                     "version": "1.0.2",
                     "bundled": true
                 },
+                "debug": {
+                    "version": "3.2.6",
+                    "bundled": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
                 "deep-extend": {
                     "version": "0.6.0",
                     "bundled": true
@@ -664,10 +641,10 @@
                     "bundled": true
                 },
                 "fs-minipass": {
-                    "version": "1.2.5",
+                    "version": "1.2.7",
                     "bundled": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "^2.6.0"
                     }
                 },
                 "fs.realpath": {
@@ -688,19 +665,31 @@
                         "wide-align": "^1.1.0"
                     }
                 },
+                "glob": {
+                    "version": "7.1.4",
+                    "bundled": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
                 "has-unicode": {
                     "version": "2.0.1",
                     "bundled": true
                 },
                 "iconv-lite": {
-                    "version": "0.4.23",
+                    "version": "0.4.24",
                     "bundled": true,
                     "requires": {
                         "safer-buffer": ">= 2.1.2 < 3"
                     }
                 },
                 "ignore-walk": {
-                    "version": "3.0.1",
+                    "version": "3.0.3",
                     "bundled": true,
                     "requires": {
                         "minimatch": "^3.0.4"
@@ -715,7 +704,7 @@
                     }
                 },
                 "inherits": {
-                    "version": "2.0.3",
+                    "version": "2.0.4",
                     "bundled": true
                 },
                 "ini": {
@@ -745,7 +734,7 @@
                     "bundled": true
                 },
                 "minipass": {
-                    "version": "2.3.5",
+                    "version": "2.9.0",
                     "bundled": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
@@ -753,10 +742,10 @@
                     }
                 },
                 "minizlib": {
-                    "version": "1.2.1",
+                    "version": "1.3.3",
                     "bundled": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "^2.9.0"
                     }
                 },
                 "mkdirp": {
@@ -772,30 +761,21 @@
                         }
                     }
                 },
+                "ms": {
+                    "version": "2.1.2",
+                    "bundled": true
+                },
                 "needle": {
-                    "version": "2.3.1",
+                    "version": "2.4.0",
                     "bundled": true,
                     "requires": {
-                        "debug": "^4.1.0",
+                        "debug": "^3.2.6",
                         "iconv-lite": "^0.4.4",
                         "sax": "^1.2.4"
-                    },
-                    "dependencies": {
-                        "debug": {
-                            "version": "4.1.1",
-                            "bundled": true,
-                            "requires": {
-                                "ms": "^2.1.1"
-                            }
-                        },
-                        "ms": {
-                            "version": "2.1.1",
-                            "bundled": true
-                        }
                     }
                 },
                 "node-pre-gyp": {
-                    "version": "0.13.0",
+                    "version": "0.14.0",
                     "bundled": true,
                     "requires": {
                         "detect-libc": "^1.0.2",
@@ -807,7 +787,7 @@
                         "rc": "^1.2.7",
                         "rimraf": "^2.6.1",
                         "semver": "^5.3.0",
-                        "tar": "^4"
+                        "tar": "^4.4.2"
                     }
                 },
                 "nopt": {
@@ -823,7 +803,7 @@
                     "bundled": true
                 },
                 "npm-packlist": {
-                    "version": "1.4.1",
+                    "version": "1.4.6",
                     "bundled": true,
                     "requires": {
                         "ignore-walk": "^3.0.1",
@@ -876,7 +856,7 @@
                     "bundled": true
                 },
                 "process-nextick-args": {
-                    "version": "2.0.0",
+                    "version": "2.0.1",
                     "bundled": true
                 },
                 "protobufjs": {
@@ -914,24 +894,10 @@
                     }
                 },
                 "rimraf": {
-                    "version": "2.6.3",
+                    "version": "2.7.1",
                     "bundled": true,
                     "requires": {
                         "glob": "^7.1.3"
-                    },
-                    "dependencies": {
-                        "glob": {
-                            "version": "7.1.4",
-                            "bundled": true,
-                            "requires": {
-                                "fs.realpath": "^1.0.0",
-                                "inflight": "^1.0.4",
-                                "inherits": "2",
-                                "minimatch": "^3.0.4",
-                                "once": "^1.3.0",
-                                "path-is-absolute": "^1.0.0"
-                            }
-                        }
                     }
                 },
                 "safe-buffer": {
@@ -947,7 +913,7 @@
                     "bundled": true
                 },
                 "semver": {
-                    "version": "5.7.0",
+                    "version": "5.7.1",
                     "bundled": true
                 },
                 "set-blocking": {
@@ -986,16 +952,16 @@
                     "bundled": true
                 },
                 "tar": {
-                    "version": "4.4.8",
+                    "version": "4.4.13",
                     "bundled": true,
                     "requires": {
                         "chownr": "^1.1.1",
                         "fs-minipass": "^1.2.5",
-                        "minipass": "^2.3.4",
-                        "minizlib": "^1.1.1",
+                        "minipass": "^2.8.6",
+                        "minizlib": "^1.2.1",
                         "mkdirp": "^0.5.0",
                         "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.2"
+                        "yallist": "^3.0.3"
                     }
                 },
                 "util-deprecate": {
@@ -1014,7 +980,7 @@
                     "bundled": true
                 },
                 "yallist": {
-                    "version": "3.0.3",
+                    "version": "3.1.1",
                     "bundled": true
                 }
             }
@@ -1034,22 +1000,19 @@
             "dev": true
         },
         "has-symbols": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
         },
         "hosted-git-info": {
-            "version": "2.8.2",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz",
-            "integrity": "sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==",
-            "requires": {
-                "lru-cache": "^5.1.1"
-            }
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+            "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
         },
         "ieee754": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-            "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
         },
         "inflight": {
             "version": "1.0.6",
@@ -1071,14 +1034,14 @@
             "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
         },
         "is-callable": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+            "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
         },
         "is-date-object": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+            "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
         },
         "is-fullwidth-code-point": {
             "version": "1.0.0",
@@ -1089,19 +1052,19 @@
             }
         },
         "is-regex": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+            "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
             "requires": {
-                "has": "^1.0.1"
+                "has": "^1.0.3"
             }
         },
         "is-symbol": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-            "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+            "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
             "requires": {
-                "has-symbols": "^1.0.0"
+                "has-symbols": "^1.0.1"
             }
         },
         "isarray": {
@@ -1158,18 +1121,10 @@
             "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
             "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
         },
-        "lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-            "requires": {
-                "yallist": "^3.0.2"
-            }
-        },
         "make-error": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-            "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
         },
         "mime": {
             "version": "2.4.4",
@@ -1190,20 +1145,20 @@
             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "minipass": {
-            "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-            "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+            "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
             "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
             }
         },
         "minizlib": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-            "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+            "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
             "requires": {
-                "minipass": "^2.2.1"
+                "minipass": "^2.9.0"
             }
         },
         "mkdirp": {
@@ -1240,25 +1195,53 @@
                 "resolve": "^1.10.0",
                 "semver": "2 || 3 || 4 || 5",
                 "validate-npm-package-license": "^3.0.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                }
             }
+        },
+        "npm-normalize-package-bin": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+            "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
         },
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
+        "object-inspect": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+            "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+        },
         "object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
         },
-        "object.getownpropertydescriptors": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-            "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "requires": {
                 "define-properties": "^1.1.2",
-                "es-abstract": "^1.5.1"
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
+            }
+        },
+        "object.getownpropertydescriptors": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+            "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1"
             }
         },
         "once": {
@@ -1313,9 +1296,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "10.14.14",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.14.tgz",
-                    "integrity": "sha512-xXD08vZsvpv4xptQXj1+ky22f7ZoKu5ZNI/4l+/BXG3X+XaeZsmaFbbTKuhSE3NjjvRuZFxFf9sQBMXIcZNFMQ=="
+                    "version": "10.17.17",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
+                    "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
                 },
                 "long": {
                     "version": "4.0.0",
@@ -1335,15 +1318,15 @@
             "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
         },
         "read-package-json": {
-            "version": "2.0.13",
-            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
-            "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
+            "integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
             "requires": {
                 "glob": "^7.1.1",
                 "graceful-fs": "^4.1.2",
                 "json-parse-better-errors": "^1.0.1",
                 "normalize-package-data": "^2.0.0",
-                "slash": "^1.0.0"
+                "npm-normalize-package-bin": "^1.0.0"
             }
         },
         "read-package-tree": {
@@ -1373,17 +1356,17 @@
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
         },
         "resolve": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-            "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+            "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
             "requires": {
                 "path-parse": "^1.0.6"
             }
         },
         "rimraf": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
             "requires": {
                 "glob": "^7.1.3"
             }
@@ -1399,14 +1382,9 @@
             "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
         },
         "semver": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
-        },
-        "slash": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "source-map": {
             "version": "0.5.7",
@@ -1465,6 +1443,24 @@
                 "strip-ansi": "^3.0.0"
             }
         },
+        "string.prototype.trimleft": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+            "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+            "requires": {
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
+            }
+        },
+        "string.prototype.trimright": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+            "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+            "requires": {
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
+            }
+        },
         "strip-ansi": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -1483,13 +1479,13 @@
             }
         },
         "tar": {
-            "version": "4.4.10",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
-            "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
+            "version": "4.4.13",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+            "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
             "requires": {
                 "chownr": "^1.1.1",
                 "fs-minipass": "^1.2.5",
-                "minipass": "^2.3.5",
+                "minipass": "^2.8.6",
                 "minizlib": "^1.2.1",
                 "mkdirp": "^0.5.0",
                 "safe-buffer": "^5.1.2",
@@ -1505,18 +1501,15 @@
             }
         },
         "ts-node": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
-            "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+            "version": "8.5.4",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
+            "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
             "requires": {
-                "arrify": "^1.0.0",
-                "buffer-from": "^1.1.0",
-                "diff": "^3.1.0",
+                "arg": "^4.1.0",
+                "diff": "^4.0.1",
                 "make-error": "^1.1.1",
-                "minimist": "^1.2.0",
-                "mkdirp": "^0.5.1",
                 "source-map-support": "^0.5.6",
-                "yn": "^2.0.0"
+                "yn": "^3.0.0"
             },
             "dependencies": {
                 "source-map": {
@@ -1525,9 +1518,9 @@
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
                 },
                 "source-map-support": {
-                    "version": "0.5.13",
-                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-                    "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+                    "version": "0.5.16",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+                    "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
                     "requires": {
                         "buffer-from": "^1.0.0",
                         "source-map": "^0.6.0"
@@ -1536,22 +1529,22 @@
             }
         },
         "tslib": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-            "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+            "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
             "dev": true
         },
         "tslint": {
-            "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.18.0.tgz",
-            "integrity": "sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==",
+            "version": "5.20.1",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
+            "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
                 "builtin-modules": "^1.1.1",
                 "chalk": "^2.3.0",
                 "commander": "^2.12.1",
-                "diff": "^3.2.0",
+                "diff": "^4.0.1",
                 "glob": "^7.1.1",
                 "js-yaml": "^3.13.1",
                 "minimatch": "^3.0.4",
@@ -1566,6 +1559,12 @@
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
                     "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "dev": true
                 }
             }
@@ -1586,9 +1585,9 @@
             "dev": true
         },
         "upath": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
-            "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q=="
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+            "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
         },
         "url": {
             "version": "0.10.3",
@@ -1608,9 +1607,9 @@
             }
         },
         "uuid": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
         "validate-npm-package-license": {
             "version": "3.0.4",
@@ -1660,9 +1659,9 @@
             "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
         },
         "yallist": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-            "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         },
         "yargs": {
             "version": "3.32.0",
@@ -1679,9 +1678,9 @@
             }
         },
         "yn": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-            "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
         }
     }
 }

--- a/infra/pulumify
+++ b/infra/pulumify
@@ -113,8 +113,9 @@ if [ "$PULUMI_UPDATE" = true ]; then
     # If the stack doesn't exist yet, create it.
     if [ $PULUMI_STACK_EXISTS -ne 0 ]; then
         pulumi stack init $PULUMI_STACK_NAME
-        pulumi config set root $GITHUB_WORKSPACE/${PULUMIFY_ROOT:-public}
-        pulumi config set aws:region ${AWS_REGION:-us-east-1}
+        pulumi config set root $GITHUB_WORKSPACE/${PULUMIFY_ROOT:-"public"}
+        pulumi config set syncStrategy ${PULUMIFY_SYNC_STRATEGY:-"server-lambda"}
+        pulumi config set aws:region ${AWS_REGION:-"us-east-1"}
     fi
 
     # Now simply run an update to provision and/or update the static website.


### PR DESCRIPTION
This change adds sync options to the BucketDirectory
component resource. Namely, this now offers four strategies
for how to go about the S3 object sync:

* "remote-lambda" (default): the current strategy of tgz'ing
  the files locally, uploading them to S3, and then running a
  server-side lambda to un-tgz and sync the files. Benefit of
  server-side execution and minimal infrastructure needed, but
  sadly tops out at 512MB.

* "remote-ecstask": a similar strategy of locally tgz'ing and
  copying, but uses an ECS Fargate task for the server-side sync.

* "local-copy": simply creates S3 Objects for each file, so
  there is an asset and a resource allocated for each one. This
  runs purely locally and is the naive way to do this in Pulumi,
  but has quite a bit of overhead and copies a file at a time.

* "local-sync": uses the AWS CLI to perform a local `aws s3 sync`
  operation. Doesn't require server-side machinery, but will copy
  each file individually, so it's slower. But it avoids the
  per-file asset and resource and so is less costly than local-copy.

This gives users more control over sync'ing behavior as one
strategy or the other may be best. For instance, with small sites,
remote-lambda is fast and great -- but for large sites, it won't
work. And although remote-ecstask is a reasonable alternative,
it requires a fair bit of infrastructure complexity.