### PR TITLE
Upgrade dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM pulumi/pulumi:v1.14.0
+FROM pulumi/pulumi:v2.2.1
 
 # Label things so it lights up in GitHub Actions!
 LABEL "com.github.actions.name"="Pulumify"
 LABEL "com.github.actions.description"="Deploy static websites to your favorite cloud!"
 LABEL "com.github.actions.icon"="cloud-lightning"
 LABEL "com.github.actions.color"="purple"
-LABEL "repository"="https://github.com/joeduffy/pulumify"
-LABEL "homepage"="http://pulumi.com/docs"
-LABEL "maintainer"="Joe Duffy <joe@pulumi.com>"
+LABEL "repository"="https://github.com/pulumi/actions-pulumify"
+LABEL "homepage"="https://pulumi.com/"
+LABEL "maintainer"="Pulumi Team <team@pulumi.com>"
 
 # Install some tools we'll need.
 RUN apt-get update -y

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To enable Pulumify in your repo, do the following:
 
 2) [Configure your GitHub secrets](
    https://help.github.com/en/articles/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables).
-   This must include your [`PULUMI_ACCESS_TOKEN`](https://app.pulumi.com/joeduffy/settings/tokens) in addition to your
+   This must include your [`PULUMI_ACCESS_TOKEN`](https://app.pulumi.com/account/tokens) in addition to your
    cloud credentials. For example, to deploy to AWS, you'll need `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` values
    with appropriate IAM permissions to deploy an S3 website to your account.
 
@@ -33,7 +33,7 @@ To enable Pulumify in your repo, do the following:
         name: Update Live Preview
         runs-on: ubuntu-latest
         steps:
-        - uses: docker://joeduffy/pulumify
+        - uses: docker://pulumi/pulumify
           env:
             AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/infra/bucketDirectory.ts
+++ b/infra/bucketDirectory.ts
@@ -44,7 +44,7 @@ export class BucketDirectory extends pulumi.ComponentResource {
     /**
      * The child resource allocated to perform the directory sync'ing.
      */
-    private readonly syncer: BucketDirectoryLambdaSyncer;
+    private readonly syncer?: BucketDirectoryLambdaSyncer;
 
     /**
      * Provisions a new BucketDirectory resource with a given name, arguments, and options.

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -3,24 +3,12 @@
     "requires": true,
     "lockfileVersion": 1,
     "dependencies": {
-        "@babel/code-frame": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-            "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-            "dev": true,
+        "@grpc/grpc-js": {
+            "version": "0.6.18",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.6.18.tgz",
+            "integrity": "sha512-uAzv/tM8qpbf1vpx1xPMfcUMzbfdqJtdCYAqY/LsLeQQlnTb4vApylojr+wlCyr7bZeg3AFfHvtihnNOQQt/nA==",
             "requires": {
-                "@babel/highlight": "^7.8.3"
-            }
-        },
-        "@babel/highlight": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-            "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-            "dev": true,
-            "requires": {
-                "chalk": "^2.0.0",
-                "esutils": "^2.0.2",
-                "js-tokens": "^4.0.0"
+                "semver": "^6.2.0"
             }
         },
         "@protobufjs/aspromise": {
@@ -78,11 +66,11 @@
             "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
         },
         "@pulumi/aws": {
-            "version": "1.23.0",
-            "resolved": "https://registry.npmjs.org/@pulumi/aws/-/aws-1.23.0.tgz",
-            "integrity": "sha512-nAl+GdbGDE+fGwnT2VQQJ5aWsJhL/Z5DHOV+hHgP+ksadpl6U1f/F64Ln+3nu92imYSvexDcnR/tH1dYjo0rWQ==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/aws/-/aws-2.4.0.tgz",
+            "integrity": "sha512-DsTlZEUY2tuovBPmJHfGA58l3E/PLWvjzs7F0lEH15uNO7UgWocU/dgPYSOy25yzePuNreeei0EJqGZwIK8NzQ==",
             "requires": {
-                "@pulumi/pulumi": "^1.0.0",
+                "@pulumi/pulumi": "^2.0.0",
                 "aws-sdk": "^2.0.0",
                 "builtin-modules": "3.0.0",
                 "mime": "^2.0.0",
@@ -91,24 +79,21 @@
             }
         },
         "@pulumi/awsx": {
-            "version": "0.18.14",
-            "resolved": "https://registry.npmjs.org/@pulumi/awsx/-/awsx-0.18.14.tgz",
-            "integrity": "sha512-2etPn1fCPSk+xpIow9vqS398SVmNZlmJe3gP7icWSZeaON8ActfYE/89JEWLSSkWkzc7h8P+LavkLg2sYWmGnw==",
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/awsx/-/awsx-0.20.0.tgz",
+            "integrity": "sha512-ZYe3aH4hsxWPbjh9fgvZg3iExNDdEBBWXC1tpfuZgaU4+oxKixo9vZ74cb5N9DUH7AKf4H4ZTRApF32WsDa5xw==",
             "requires": {
-                "@pulumi/aws": "^1.0.0",
-                "@pulumi/docker": "^0.17.3",
-                "@pulumi/pulumi": "^1.0.0",
+                "@pulumi/docker": "^1.0.0 || ^2.0.0",
                 "@types/aws-lambda": "^8.10.23",
-                "deasync": "^0.1.15",
                 "mime": "^2.0.0"
             }
         },
         "@pulumi/docker": {
-            "version": "0.17.4",
-            "resolved": "https://registry.npmjs.org/@pulumi/docker/-/docker-0.17.4.tgz",
-            "integrity": "sha512-uGnt9VEGXxCFTpIkCrULP2XTbSEJMH3vQrOq9Q+ATTnIxswlG0z/LkpuktEB6YmvnQqEUtTPPEM+p/RmLkqLrA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@pulumi/docker/-/docker-2.1.1.tgz",
+            "integrity": "sha512-2DlmXrx0IKMZdqNb3ZaYtThiUOhDD9rUHggkuFHvbTATT3G+22gO92PTmaNYbTIxXlteXu7pphvAjbkWyb1tKA==",
             "requires": {
-                "@pulumi/pulumi": "^1.0.0",
+                "@pulumi/pulumi": "^2.0.0",
                 "semver": "^5.4.0"
             },
             "dependencies": {
@@ -120,14 +105,13 @@
             }
         },
         "@pulumi/pulumi": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-1.11.1.tgz",
-            "integrity": "sha512-f3s1vghGAt3wVtBAuahbEdNp1X6iP0xTA8aSSmzwkHGfSdOu9FLERXRLJVsTZRBVshF1Jh+0wHYdRLahWxVpJw==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-2.2.1.tgz",
+            "integrity": "sha512-TuYyTqhjtbLNbXAEgBrkObfYX5fef5j2g39Qybg4BCccprmZ5Q/cqgnw0GYdqlyQaKWuuFosiOm8/6RqxmHGsw==",
             "requires": {
+                "@grpc/grpc-js": "^0.6.15",
                 "@pulumi/query": "^0.3.0",
-                "deasync": "^0.1.15",
                 "google-protobuf": "^3.5.0",
-                "grpc": "1.24.2",
                 "minimist": "^1.2.0",
                 "normalize-package-data": "^2.4.0",
                 "protobufjs": "^6.8.6",
@@ -135,7 +119,7 @@
                 "require-from-string": "^2.0.1",
                 "semver": "^6.1.0",
                 "source-map-support": "^0.4.16",
-                "ts-node": "8.5.4",
+                "ts-node": "^7.0.1",
                 "typescript": "~3.7.3",
                 "upath": "^1.1.0"
             },
@@ -153,25 +137,9 @@
             "integrity": "sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w=="
         },
         "@types/aws-lambda": {
-            "version": "8.10.46",
-            "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.46.tgz",
-            "integrity": "sha512-88E4Hlypo3AE40wslm7N4n09lCIJwgYJm5wsaA3/Vib1xqjC/ANePTaPRpPdj9NzBSpw7Tgon58qGMYEArx4oA=="
-        },
-        "@types/bytebuffer": {
-            "version": "5.0.40",
-            "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
-            "integrity": "sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==",
-            "requires": {
-                "@types/long": "*",
-                "@types/node": "*"
-            },
-            "dependencies": {
-                "@types/node": {
-                    "version": "13.7.7",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.7.tgz",
-                    "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg=="
-                }
-            }
+            "version": "8.10.51",
+            "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.51.tgz",
+            "integrity": "sha512-XK7RerpXj4r+IO0r7qIeNqUSU6L4qhPMwNhISxozJJiUX/jdXj9WYzTShRVisEcUQHXgJ4TTBqTArM8f9Mjb8g=="
         },
         "@types/long": {
             "version": "4.0.1",
@@ -188,6 +156,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@types/minipass/-/minipass-2.2.0.tgz",
             "integrity": "sha512-wuzZksN4w4kyfoOv/dlpov4NOunwutLA/q7uc00xU02ZyUY+aoM5PWIXEKBMnm0NHd4a+N71BMjq+x7+2Af1fg==",
+            "dev": true,
             "requires": {
                 "@types/node": "*"
             },
@@ -195,7 +164,8 @@
                 "@types/node": {
                     "version": "13.7.7",
                     "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.7.tgz",
-                    "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg=="
+                    "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg==",
+                    "dev": true
                 }
             }
         },
@@ -209,6 +179,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/@types/tar/-/tar-4.0.3.tgz",
             "integrity": "sha512-Z7AVMMlkI8NTWF0qGhC4QIX0zkV/+y0J8x7b/RsHrN0310+YNjoJd8UrApCiGBCWtKjxS9QhNqLi2UJNToh5hA==",
+            "dev": true,
             "requires": {
                 "@types/minipass": "*",
                 "@types/node": "*"
@@ -217,61 +188,32 @@
                 "@types/node": {
                     "version": "13.7.7",
                     "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.7.tgz",
-                    "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg=="
+                    "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg==",
+                    "dev": true
                 }
             }
         },
         "@types/tmp": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.1.0.tgz",
-            "integrity": "sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA=="
+            "integrity": "sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==",
+            "dev": true
         },
         "@types/uuid": {
             "version": "3.4.8",
             "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.8.tgz",
-            "integrity": "sha512-zHWce3allXWSmRx6/AGXKCtSOA7JjeWd2L3t4aHfysNk8mouQnWCocveaT7a4IEIlPVHp81jzlnknqTgCjCLXA=="
+            "integrity": "sha512-zHWce3allXWSmRx6/AGXKCtSOA7JjeWd2L3t4aHfysNk8mouQnWCocveaT7a4IEIlPVHp81jzlnknqTgCjCLXA==",
+            "dev": true
         },
-        "ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
-            "requires": {
-                "color-convert": "^1.9.0"
-            }
-        },
-        "arg": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
-        },
-        "argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "requires": {
-                "sprintf-js": "~1.0.2"
-            }
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
         },
         "asap": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
             "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-        },
-        "ascli": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
-            "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
-            "requires": {
-                "colour": "~0.7.1",
-                "optjs": "~3.2.2"
-            }
         },
         "aws-sdk": {
             "version": "2.631.0",
@@ -306,14 +248,6 @@
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
             "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
         },
-        "bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "requires": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -343,99 +277,20 @@
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.0.0.tgz",
             "integrity": "sha512-hMIeU4K2ilbXV6Uv93ZZ0Avg/M91RaKXucQ+4me2Do1txxBDyDZWCBa5bJSLqoNTRpXTLwEzIk1KmloenDDjhg=="
         },
-        "bytebuffer": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
-            "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
-            "requires": {
-                "long": "~3"
-            }
-        },
-        "camelcase": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-        },
-        "chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            }
-        },
         "chownr": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
             "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-        },
-        "cliui": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-            "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wrap-ansi": "^2.0.0"
-            }
-        },
-        "code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
-        "color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "requires": {
-                "color-name": "1.1.3"
-            }
-        },
-        "color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
-        },
-        "colour": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
-            "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
-        },
-        "commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
-        "deasync": {
-            "version": "0.1.19",
-            "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.19.tgz",
-            "integrity": "sha512-oh3MRktfnPlLysCPpBpKZZzb4cUC/p0aA3SyRGp15lN30juJBTo/CiD0d4fR+f1kBtUQoJj1NE9RPNWQ7BQ9Mg==",
-            "requires": {
-                "bindings": "^1.5.0",
-                "node-addon-api": "^1.7.1"
-            }
-        },
         "debuglog": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
             "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
-        },
-        "decamelize": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
         "define-properties": {
             "version": "1.1.3",
@@ -454,15 +309,10 @@
                 "wrappy": "1"
             }
         },
-        "diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
-        },
         "es-abstract": {
-            "version": "1.17.4",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-            "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+            "version": "1.17.5",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+            "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
             "requires": {
                 "es-to-primitive": "^1.2.1",
                 "function-bind": "^1.1.1",
@@ -487,33 +337,10 @@
                 "is-symbol": "^1.0.2"
             }
         },
-        "escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
-        },
-        "esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true
-        },
-        "esutils": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "dev": true
-        },
         "events": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
             "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-        },
-        "file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
         },
         "fs-minipass": {
             "version": "1.2.7",
@@ -552,438 +379,9 @@
             "integrity": "sha512-lL6b04rDirurUBOgsY2+LalI6Evq8eH5TcNzi7TYQ3BsIWelT0KSOQSBsXuavEkNf+odQU6c0lgz3UsZXeNX9Q=="
         },
         "graceful-fs": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-            "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
-        },
-        "grpc": {
-            "version": "1.24.2",
-            "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.2.tgz",
-            "integrity": "sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==",
-            "requires": {
-                "@types/bytebuffer": "^5.0.40",
-                "lodash.camelcase": "^4.3.0",
-                "lodash.clone": "^4.5.0",
-                "nan": "^2.13.2",
-                "node-pre-gyp": "^0.14.0",
-                "protobufjs": "^5.0.3"
-            },
-            "dependencies": {
-                "abbrev": {
-                    "version": "1.1.1",
-                    "bundled": true
-                },
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "bundled": true
-                },
-                "aproba": {
-                    "version": "1.2.0",
-                    "bundled": true
-                },
-                "are-we-there-yet": {
-                    "version": "1.1.5",
-                    "bundled": true,
-                    "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^2.0.6"
-                    }
-                },
-                "balanced-match": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "brace-expansion": {
-                    "version": "1.1.11",
-                    "bundled": true,
-                    "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                    }
-                },
-                "chownr": {
-                    "version": "1.1.3",
-                    "bundled": true
-                },
-                "code-point-at": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "concat-map": {
-                    "version": "0.0.1",
-                    "bundled": true
-                },
-                "console-control-strings": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "core-util-is": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "debug": {
-                    "version": "3.2.6",
-                    "bundled": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "deep-extend": {
-                    "version": "0.6.0",
-                    "bundled": true
-                },
-                "delegates": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "detect-libc": {
-                    "version": "1.0.3",
-                    "bundled": true
-                },
-                "fs-minipass": {
-                    "version": "1.2.7",
-                    "bundled": true,
-                    "requires": {
-                        "minipass": "^2.6.0"
-                    }
-                },
-                "fs.realpath": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "gauge": {
-                    "version": "2.7.4",
-                    "bundled": true,
-                    "requires": {
-                        "aproba": "^1.0.3",
-                        "console-control-strings": "^1.0.0",
-                        "has-unicode": "^2.0.0",
-                        "object-assign": "^4.1.0",
-                        "signal-exit": "^3.0.0",
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wide-align": "^1.1.0"
-                    }
-                },
-                "glob": {
-                    "version": "7.1.4",
-                    "bundled": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "has-unicode": {
-                    "version": "2.0.1",
-                    "bundled": true
-                },
-                "iconv-lite": {
-                    "version": "0.4.24",
-                    "bundled": true,
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
-                    }
-                },
-                "ignore-walk": {
-                    "version": "3.0.3",
-                    "bundled": true,
-                    "requires": {
-                        "minimatch": "^3.0.4"
-                    }
-                },
-                "inflight": {
-                    "version": "1.0.6",
-                    "bundled": true,
-                    "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
-                    }
-                },
-                "inherits": {
-                    "version": "2.0.4",
-                    "bundled": true
-                },
-                "ini": {
-                    "version": "1.3.5",
-                    "bundled": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "bundled": true,
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "bundled": true
-                },
-                "minipass": {
-                    "version": "2.9.0",
-                    "bundled": true,
-                    "requires": {
-                        "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.0"
-                    }
-                },
-                "minizlib": {
-                    "version": "1.3.3",
-                    "bundled": true,
-                    "requires": {
-                        "minipass": "^2.9.0"
-                    }
-                },
-                "mkdirp": {
-                    "version": "0.5.1",
-                    "bundled": true,
-                    "requires": {
-                        "minimist": "0.0.8"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "0.0.8",
-                            "bundled": true
-                        }
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "bundled": true
-                },
-                "needle": {
-                    "version": "2.4.0",
-                    "bundled": true,
-                    "requires": {
-                        "debug": "^3.2.6",
-                        "iconv-lite": "^0.4.4",
-                        "sax": "^1.2.4"
-                    }
-                },
-                "node-pre-gyp": {
-                    "version": "0.14.0",
-                    "bundled": true,
-                    "requires": {
-                        "detect-libc": "^1.0.2",
-                        "mkdirp": "^0.5.1",
-                        "needle": "^2.2.1",
-                        "nopt": "^4.0.1",
-                        "npm-packlist": "^1.1.6",
-                        "npmlog": "^4.0.2",
-                        "rc": "^1.2.7",
-                        "rimraf": "^2.6.1",
-                        "semver": "^5.3.0",
-                        "tar": "^4.4.2"
-                    }
-                },
-                "nopt": {
-                    "version": "4.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "abbrev": "1",
-                        "osenv": "^0.1.4"
-                    }
-                },
-                "npm-bundled": {
-                    "version": "1.0.6",
-                    "bundled": true
-                },
-                "npm-packlist": {
-                    "version": "1.4.6",
-                    "bundled": true,
-                    "requires": {
-                        "ignore-walk": "^3.0.1",
-                        "npm-bundled": "^1.0.1"
-                    }
-                },
-                "npmlog": {
-                    "version": "4.1.2",
-                    "bundled": true,
-                    "requires": {
-                        "are-we-there-yet": "~1.1.2",
-                        "console-control-strings": "~1.1.0",
-                        "gauge": "~2.7.3",
-                        "set-blocking": "~2.0.0"
-                    }
-                },
-                "number-is-nan": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "object-assign": {
-                    "version": "4.1.1",
-                    "bundled": true
-                },
-                "once": {
-                    "version": "1.4.0",
-                    "bundled": true,
-                    "requires": {
-                        "wrappy": "1"
-                    }
-                },
-                "os-homedir": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "os-tmpdir": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "osenv": {
-                    "version": "0.1.5",
-                    "bundled": true,
-                    "requires": {
-                        "os-homedir": "^1.0.0",
-                        "os-tmpdir": "^1.0.0"
-                    }
-                },
-                "path-is-absolute": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "process-nextick-args": {
-                    "version": "2.0.1",
-                    "bundled": true
-                },
-                "protobufjs": {
-                    "version": "5.0.3",
-                    "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
-                    "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
-                    "requires": {
-                        "ascli": "~1",
-                        "bytebuffer": "~5",
-                        "glob": "^7.0.5",
-                        "yargs": "^3.10.0"
-                    }
-                },
-                "rc": {
-                    "version": "1.2.8",
-                    "bundled": true,
-                    "requires": {
-                        "deep-extend": "^0.6.0",
-                        "ini": "~1.3.0",
-                        "minimist": "^1.2.0",
-                        "strip-json-comments": "~2.0.1"
-                    }
-                },
-                "readable-stream": {
-                    "version": "2.3.6",
-                    "bundled": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "rimraf": {
-                    "version": "2.7.1",
-                    "bundled": true,
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "bundled": true
-                },
-                "safer-buffer": {
-                    "version": "2.1.2",
-                    "bundled": true
-                },
-                "sax": {
-                    "version": "1.2.4",
-                    "bundled": true
-                },
-                "semver": {
-                    "version": "5.7.1",
-                    "bundled": true
-                },
-                "set-blocking": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "signal-exit": {
-                    "version": "3.0.2",
-                    "bundled": true
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                },
-                "strip-json-comments": {
-                    "version": "2.0.1",
-                    "bundled": true
-                },
-                "tar": {
-                    "version": "4.4.13",
-                    "bundled": true,
-                    "requires": {
-                        "chownr": "^1.1.1",
-                        "fs-minipass": "^1.2.5",
-                        "minipass": "^2.8.6",
-                        "minizlib": "^1.2.1",
-                        "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.3"
-                    }
-                },
-                "util-deprecate": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "wide-align": {
-                    "version": "1.1.3",
-                    "bundled": true,
-                    "requires": {
-                        "string-width": "^1.0.2 || 2"
-                    }
-                },
-                "wrappy": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "yallist": {
-                    "version": "3.1.1",
-                    "bundled": true
-                }
-            }
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
         },
         "has": {
             "version": "1.0.3",
@@ -992,12 +390,6 @@
             "requires": {
                 "function-bind": "^1.1.1"
             }
-        },
-        "has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
         },
         "has-symbols": {
             "version": "1.0.1",
@@ -1028,11 +420,6 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
-        "invert-kv": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-        },
         "is-callable": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
@@ -1042,14 +429,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
             "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
-        },
-        "is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "requires": {
-                "number-is-nan": "^1.0.0"
-            }
         },
         "is-regex": {
             "version": "1.0.5",
@@ -1077,49 +456,15 @@
             "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
             "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
         },
-        "js-tokens": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
-        },
-        "js-yaml": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-            "dev": true,
-            "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            }
-        },
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
         },
-        "lcid": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-            "requires": {
-                "invert-kv": "^1.0.0"
-            }
-        },
-        "lodash.camelcase": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-            "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-        },
-        "lodash.clone": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
-            "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
-        },
         "long": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-            "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
         },
         "make-error": {
             "version": "1.3.6",
@@ -1140,9 +485,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "minipass": {
             "version": "2.9.0",
@@ -1176,16 +521,6 @@
                 }
             }
         },
-        "nan": {
-            "version": "2.14.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-            "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-        },
-        "node-addon-api": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
-            "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ=="
-        },
         "normalize-package-data": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -1208,11 +543,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
             "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
-        },
-        "number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-inspect": {
             "version": "1.7.0",
@@ -1252,19 +582,6 @@
                 "wrappy": "1"
             }
         },
-        "optjs": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
-            "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
-        },
-        "os-locale": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-            "requires": {
-                "lcid": "^1.0.0"
-            }
-        },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1276,9 +593,9 @@
             "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
         },
         "protobufjs": {
-            "version": "6.8.8",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-            "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+            "version": "6.9.0",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.9.0.tgz",
+            "integrity": "sha512-LlGVfEWDXoI/STstRDdZZKb/qusoAWUnmLg9R8OLSO473mBLWHowx8clbX5/+mKDEI+v7GzjoK9tRPZMMcoTrg==",
             "requires": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
@@ -1290,20 +607,15 @@
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.0",
-                "@types/long": "^4.0.0",
-                "@types/node": "^10.1.0",
+                "@types/long": "^4.0.1",
+                "@types/node": "^13.7.0",
                 "long": "^4.0.0"
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "10.17.17",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-                    "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
-                },
-                "long": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-                    "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+                    "version": "13.13.6",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.6.tgz",
+                    "integrity": "sha512-zqRj8ugfROCjXCNbmPBe2mmQ0fJWP9lQaN519hwunOgpHgVykme4G6FW95++dyNFDvJUk4rtExkVkL0eciu5NA=="
                 }
             }
         },
@@ -1409,14 +721,14 @@
             }
         },
         "spdx-exceptions": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
         },
         "spdx-expression-parse": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
             "requires": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
@@ -1427,55 +739,42 @@
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
             "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
         },
-        "sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
-        },
-        "string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+        "string.prototype.trimend": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+            "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
             "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5"
             }
         },
         "string.prototype.trimleft": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-            "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+            "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
             "requires": {
                 "define-properties": "^1.1.3",
-                "function-bind": "^1.1.1"
+                "es-abstract": "^1.17.5",
+                "string.prototype.trimstart": "^1.0.0"
             }
         },
         "string.prototype.trimright": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-            "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+            "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
             "requires": {
                 "define-properties": "^1.1.3",
-                "function-bind": "^1.1.1"
+                "es-abstract": "^1.17.5",
+                "string.prototype.trimend": "^1.0.0"
             }
         },
-        "strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+        "string.prototype.trimstart": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+            "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
             "requires": {
-                "ansi-regex": "^2.0.0"
-            }
-        },
-        "supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "requires": {
-                "has-flag": "^3.0.0"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5"
             }
         },
         "tar": {
@@ -1501,26 +800,34 @@
             }
         },
         "ts-node": {
-            "version": "8.5.4",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
-            "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+            "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
             "requires": {
-                "arg": "^4.1.0",
-                "diff": "^4.0.1",
+                "arrify": "^1.0.0",
+                "buffer-from": "^1.1.0",
+                "diff": "^3.1.0",
                 "make-error": "^1.1.1",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
                 "source-map-support": "^0.5.6",
-                "yn": "^3.0.0"
+                "yn": "^2.0.0"
             },
             "dependencies": {
+                "diff": {
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+                    "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+                },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
                 },
                 "source-map-support": {
-                    "version": "0.5.16",
-                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-                    "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+                    "version": "0.5.19",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+                    "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
                     "requires": {
                         "buffer-from": "^1.0.0",
                         "source-map": "^0.6.0"
@@ -1528,60 +835,10 @@
                 }
             }
         },
-        "tslib": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-            "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
-            "dev": true
-        },
-        "tslint": {
-            "version": "5.20.1",
-            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-            "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "builtin-modules": "^1.1.1",
-                "chalk": "^2.3.0",
-                "commander": "^2.12.1",
-                "diff": "^4.0.1",
-                "glob": "^7.1.1",
-                "js-yaml": "^3.13.1",
-                "minimatch": "^3.0.4",
-                "mkdirp": "^0.5.1",
-                "resolve": "^1.3.2",
-                "semver": "^5.3.0",
-                "tslib": "^1.8.0",
-                "tsutils": "^2.29.0"
-            },
-            "dependencies": {
-                "builtin-modules": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-                    "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                    "dev": true
-                }
-            }
-        },
-        "tsutils": {
-            "version": "2.29.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-            "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.8.1"
-            }
-        },
         "typescript": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-            "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+            "version": "3.7.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+            "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
             "dev": true
         },
         "upath": {
@@ -1620,20 +877,6 @@
                 "spdx-expression-parse": "^3.0.0"
             }
         },
-        "window-size": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-            "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
-        },
-        "wrap-ansi": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-            "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
-            }
-        },
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1653,34 +896,15 @@
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
             "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
         },
-        "y18n": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-        },
         "yallist": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         },
-        "yargs": {
-            "version": "3.32.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-            "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-            "requires": {
-                "camelcase": "^2.0.1",
-                "cliui": "^3.0.3",
-                "decamelize": "^1.1.1",
-                "os-locale": "^1.4.0",
-                "string-width": "^1.0.1",
-                "window-size": "^0.1.4",
-                "y18n": "^3.2.0"
-            }
-        },
         "yn": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+            "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
         }
     }
 }

--- a/infra/package.json
+++ b/infra/package.json
@@ -8,16 +8,15 @@
     "devDependencies": {
         "@types/mime": "^2.0.0",
         "@types/node": "^12.7.0",
-        "tslint": "^5.10.0",
-        "typescript": "^2.7.2"
-    },
-    "dependencies": {
-        "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^0.18.8",
-        "@pulumi/pulumi": "^2.0.0",
         "@types/tar": "^4.0.3",
         "@types/tmp": "^0.1.0",
         "@types/uuid": "^3.4.5",
+        "typescript": "~3.7.3"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^2.0.0",
+        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/pulumi": "^2.0.0",
         "aws-sdk": "^2.504.0",
         "mime": "^2.0.3",
         "tar": "^4.4.10",

--- a/infra/tsconfig.json
+++ b/infra/tsconfig.json
@@ -1,10 +1,8 @@
 {
     "compilerOptions": {
+        "strict": true,
         "outDir": "bin",
-        "target": "es6",
-        "lib": [
-            "es6"
-        ],
+        "target": "es2016",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,
@@ -13,10 +11,8 @@
         "experimentalDecorators": true,
         "pretty": true,
         "noFallthroughCasesInSwitch": true,
-        "noImplicitAny": true,
         "noImplicitReturns": true,
-        "forceConsistentCasingInFileNames": true,
-        "strictNullChecks": true
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.ts"


### PR DESCRIPTION
I haven't been able to reproduce https://github.com/pulumi/pulumi-service/issues/4907, but the TypeScript compiler error makes me think it's potentially due to and older version of TypeScript not being able to handle more recent language features. So bump up all the dependencies to latest.

Also some cleanup while I was making changes here.

After this is merged, I'll publish a new version of pulumify on docker hub, and then update the docs site to use it. If that's all working ok, I'll try re-enabling our internal policy pack.