### PR TITLE
Rely on actions/checkout to do the checkout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL "maintainer"="Pulumi Team <team@pulumi.com>"
 
 # Install some tools we'll need.
 RUN apt-get update -y
-RUN apt-get install -y jq wget git make
+RUN apt-get install -y jq wget make
 
 # Install content generation tools.
 # TODO(joe): this should eventually get factored out to be pluggable, so that the

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ To enable Pulumify in your repo, do the following:
         name: Update Live Preview
         runs-on: ubuntu-latest
         steps:
+        - uses: actions/checkout@v2
         - uses: docker://pulumi/pulumify
           env:
             AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/infra/pulumify
+++ b/infra/pulumify
@@ -67,23 +67,13 @@ case "$GITHUB_EVENT_NAME" in
         ;;
 esac
 
-# If we're going to update, ensure we've sync'd the repo.
-if [ "$PULUMI_UPDATE" = true ]; then
-    echo "# Synchronizing repo ..."
-    git init
-    git remote add origin https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
-    git config gc.auto 0
-    git fetch --tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/*:refs/remotes/origin/*
-    git checkout --progress --force $GH_BRANCH
-
-    # If there is a build command, run it now to prepare the content.
-    if [ ! -z "${PULUMIFY_BUILD:-}" ]; then
-        echo "# Rebuilding content ..."
-        # IMPORTANT!!! This runs an arbitrary command. We run this in a fresh shell without access to
-        # the environment variables, so that sensitive information in the environment cannot be accessed.
-        # Notably, neither `eval $PULUMIFY_BUILD` nor `bash -c $PULUMIFY_BUILD` would do the trick.
-        env -i GITHUB_REPOSITORY=$GITHUB_REPOSITORY GITHUB_SHA=$GITHUB_SHA bash -c "$PULUMIFY_BUILD"
-    fi
+# If there is a build command, run it now to prepare the content.
+if [ ! -z "${PULUMIFY_BUILD:-}" ]; then
+    echo "# Rebuilding content ..."
+    # IMPORTANT!!! This runs an arbitrary command. We run this in a fresh shell without access to
+    # the environment variables, so that sensitive information in the environment cannot be accessed.
+    # Notably, neither `eval $PULUMIFY_BUILD` nor `bash -c $PULUMIFY_BUILD` would do the trick.
+    env -i GITHUB_REPOSITORY=$GITHUB_REPOSITORY GITHUB_SHA=$GITHUB_SHA bash -c "$PULUMIFY_BUILD"
 fi
 
 # This is a bit of a hack, but GitHub Actions hijacks the container working directory.


### PR DESCRIPTION
This change removes the code responsible for checking out the branch and adds a note to the README to use `actions/checkout` instead.

Fixes #13. 
Closes #9.